### PR TITLE
Migrate to Deno 2

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,34 +1,35 @@
 {
-  "version": "3",
-  "packages": {
-    "specifiers": {
-      "jsr:@std/assert@1.0.3": "jsr:@std/assert@1.0.3",
-      "jsr:@std/assert@^1.0.3": "jsr:@std/assert@1.0.3",
-      "jsr:@std/expect@1.0.1": "jsr:@std/expect@1.0.1",
-      "jsr:@std/fmt@1.0.1": "jsr:@std/fmt@1.0.1",
-      "jsr:@std/internal@^1.0.2": "jsr:@std/internal@1.0.2"
-    },
-    "jsr": {
-      "@std/assert@1.0.3": {
-        "integrity": "b0d03ce1ced880df67132eea140623010d415848df66f6aa5df76507ca7c26d8",
-        "dependencies": [
-          "jsr:@std/internal@^1.0.2"
-        ]
-      },
-      "@std/expect@1.0.1": {
-        "integrity": "44075d9c2cb701ddfc4d5a260da2fb26ba3cfd94c45d3a0359f63cabbf85a058",
-        "dependencies": [
-          "jsr:@std/assert@^1.0.3",
-          "jsr:@std/internal@^1.0.2"
-        ]
-      },
-      "@std/fmt@1.0.1": {
-        "integrity": "ef76c37faa7720faa8c20fd8cc74583f9b1e356dfd630c8714baa716a45856ab"
-      },
-      "@std/internal@1.0.2": {
-        "integrity": "f4cabe2021352e8bfc24e6569700df87bf070914fc38d4b23eddd20108ac4495"
-      }
-    }
+  "version": "4",
+  "specifiers": {
+    "jsr:@std/assert@1.0.3": "1.0.3",
+    "jsr:@std/assert@^1.0.3": "1.0.3",
+    "jsr:@std/expect@1.0.1": "1.0.1",
+    "jsr:@std/fmt@1.0.1": "1.0.1",
+    "jsr:@std/internal@^1.0.2": "1.0.2",
+    "jsr:@std/io@0.225.0": "0.225.0"
   },
-  "remote": {}
+  "jsr": {
+    "@std/assert@1.0.3": {
+      "integrity": "b0d03ce1ced880df67132eea140623010d415848df66f6aa5df76507ca7c26d8",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/expect@1.0.1": {
+      "integrity": "44075d9c2cb701ddfc4d5a260da2fb26ba3cfd94c45d3a0359f63cabbf85a058",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.3",
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/fmt@1.0.1": {
+      "integrity": "ef76c37faa7720faa8c20fd8cc74583f9b1e356dfd630c8714baa716a45856ab"
+    },
+    "@std/internal@1.0.2": {
+      "integrity": "f4cabe2021352e8bfc24e6569700df87bf070914fc38d4b23eddd20108ac4495"
+    },
+    "@std/io@0.225.0": {
+      "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3"
+    }
+  }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,4 @@
 export * as Colors from "jsr:@std/fmt@1.0.1/colors";
+
+export { writeAllSync } from "jsr:@std/io@0.225.0/write-all";
+export type { WriterSync } from "jsr:@std/io@0.225.0/types";

--- a/kia.tests.ts
+++ b/kia.tests.ts
@@ -1,7 +1,8 @@
+import type { WriterSync } from "./deps.ts";
 import Kia, { forPromise, Spinners } from "./mod.ts";
 import { assertThrows, expect } from "./test.deps.ts";
 
-class TestWriter implements Deno.WriterSync {
+class TestWriter implements WriterSync {
 	buffer: number[] = [];
 	writeSync(p: Uint8Array): number {
 		p.forEach((pi) => {

--- a/kia.ts
+++ b/kia.ts
@@ -7,7 +7,7 @@ import {
 	showCursor,
 	writeLine,
 } from "./util.ts";
-import { Colors } from "./deps.ts";
+import { Colors, type WriterSync } from "./deps.ts";
 
 export interface Options {
 	text: string;
@@ -16,7 +16,7 @@ export interface Options {
 	prefixText: string;
 	indent: number;
 	cursor: boolean;
-	writer: Deno.WriterSync;
+	writer: WriterSync;
 }
 type InputOptions = Partial<Options>;
 

--- a/util.ts
+++ b/util.ts
@@ -1,5 +1,4 @@
-// deno-lint-ignore-file no-deprecated-deno-api
-import { Colors } from "./deps.ts";
+import { Colors, writeAllSync, type WriterSync } from "./deps.ts";
 
 // Terminal escape sequences
 const ESC = "\x1b[";
@@ -32,12 +31,12 @@ export function colorise(color: Color) {
  * @param text The text to be written
  */
 export function writeLine(
-	writer: Deno.WriterSync,
+	writer: WriterSync,
 	encoder: TextEncoder,
 	text: string,
 	indent?: number,
 ) {
-	Deno.writeAllSync(
+	writeAllSync(
 		writer,
 		encoder.encode(`\r${indent ? ESC + indent + "C" : ""}${text}`),
 	);
@@ -46,20 +45,20 @@ export function writeLine(
 /**
  * Clears the line and performs a carriage return
  */
-export function clearLine(writer: Deno.WriterSync, encoder: TextEncoder) {
-	Deno.writeAllSync(writer, encoder.encode(ESC + "2K\r"));
+export function clearLine(writer: WriterSync, encoder: TextEncoder) {
+	writeAllSync(writer, encoder.encode(ESC + "2K\r"));
 }
 
 /**
  * Hides the terminal cursor
  */
-export function hideCursor(writer: Deno.WriterSync, encoder: TextEncoder) {
-	Deno.writeAllSync(writer, encoder.encode(ESC + "?25l"));
+export function hideCursor(writer: WriterSync, encoder: TextEncoder) {
+	writeAllSync(writer, encoder.encode(ESC + "?25l"));
 }
 
 /**
  * Shows the terminal cursor
  */
-export function showCursor(writer: Deno.WriterSync, encoder: TextEncoder) {
-	Deno.writeAllSync(writer, encoder.encode(ESC + "?25h"));
+export function showCursor(writer: WriterSync, encoder: TextEncoder) {
+	writeAllSync(writer, encoder.encode(ESC + "?25h"));
 }


### PR DESCRIPTION
moved dependencies 'writeAllSync' and 'WriterSync' to their `@std`counterparts